### PR TITLE
Fix mobile layout for 11/11 bar

### DIFF
--- a/components/shared/PromotionBar.tsx
+++ b/components/shared/PromotionBar.tsx
@@ -71,8 +71,10 @@ const PromotionBar: React.FC<PromotionBarProps> = ({ onPromotionClick, userId })
         <div className="flex items-center justify-center py-2">
           <div className="flex items-center gap-2">
             <span className="text-xl">🎉</span>
+            {/* Shorter text on mobile, full text on larger screens */}
             <span className="font-semibold text-sm sm:text-base">
-              11.11 Deal of the Year - 11% OFF All Packages!
+              <span className="hidden sm:inline">11.11 Deal of the Year - 11% OFF All Packages!</span>
+              <span className="sm:hidden">11.11 Sale - 11% OFF All Packages!</span>
             </span>
             <span className="text-xl">🎉</span>
           </div>


### PR DESCRIPTION
Use responsive text display to show shorter message on mobile screens:
- Mobile: '11.11 Sale - 11% OFF All Packages!'
- Desktop: '11.11 Deal of the Year - 11% OFF All Packages!'

This prevents the bar from splitting into 2 rows on mobile devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)