### PR TITLE
fix(chat): handle init race + lock body scroll on mobile

### DIFF
--- a/app/api/chat/initialize/route.ts
+++ b/app/api/chat/initialize/route.ts
@@ -186,13 +186,21 @@ export async function POST(request: NextRequest) {
     let conversation;
 
     if (userInfo?.userId) {
-      // For authenticated users: find existing conversation
-      const { data: existingConv } = await serverSupabase
+      // For authenticated users: find existing conversation. Use limit(1) instead
+      // of maybeSingle() so historical duplicates don't throw — pick the newest.
+      const { data: existingConvs, error: existingErr } = await serverSupabase
         .from('web_chat_conversations')
         .select('*')
         .eq('user_id', userInfo.userId)
         .eq('is_active', true)
-        .maybeSingle();
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (existingErr) {
+        throw new Error(`Failed to lookup conversation: ${existingErr.message}`);
+      }
+
+      const existingConv = existingConvs?.[0] ?? null;
 
       if (existingConv) {
         // Update existing conversation - only update session_id, NOT last_message_at
@@ -223,10 +231,45 @@ export async function POST(request: NextRequest) {
           .select()
           .single();
 
-        if (convError || !newConv) {
-          throw new Error(`Failed to create conversation: ${convError?.message}`);
+        if (convError) {
+          // Race: a parallel request created the conversation between our
+          // SELECT and INSERT. The partial unique index
+          // idx_unique_active_conversation_per_user enforces one active row
+          // per user. Re-fetch the winning row and adopt it.
+          if (convError.code === '23505') {
+            const { data: raceConvs, error: raceErr } = await serverSupabase
+              .from('web_chat_conversations')
+              .select('*')
+              .eq('user_id', userInfo.userId)
+              .eq('is_active', true)
+              .order('created_at', { ascending: false })
+              .limit(1);
+
+            const raceConv = raceConvs?.[0];
+            if (raceErr || !raceConv) {
+              throw new Error(`Failed to recover from conversation race: ${raceErr?.message ?? 'no row found after 23505'}`);
+            }
+
+            // Point the recovered conversation at our session for realtime.
+            const { data: updatedConv, error: updateError } = await serverSupabase
+              .from('web_chat_conversations')
+              .update({ session_id: chatSession.id })
+              .eq('id', raceConv.id)
+              .select()
+              .single();
+
+            if (updateError || !updatedConv) {
+              throw new Error(`Failed to update conversation after race: ${updateError?.message}`);
+            }
+            conversation = updatedConv;
+          } else {
+            throw new Error(`Failed to create conversation: ${convError.message}`);
+          }
+        } else if (!newConv) {
+          throw new Error('Failed to create conversation: No row returned');
+        } else {
+          conversation = newConv;
         }
-        conversation = newConv;
       }
     } else {
       // For anonymous users: find most recent conversation by session string

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -41,6 +41,16 @@ export function ChatWindow({
     void initializeChat();
   }, [initializeChat]);
 
+  // Lock body scroll while the chat is open so mobile swipes inside the
+  // fixed-overlay window don't bleed through and scroll the page underneath.
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
   // Mark messages from staff/bot as read while the window is open
   useEffect(() => {
     if (!chatSession.conversationId) {

--- a/hooks/useChatSession.ts
+++ b/hooks/useChatSession.ts
@@ -6,7 +6,7 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { createClient } from '@/utils/supabase/client';
 import { useSession } from 'next-auth/react';
 
@@ -44,6 +44,11 @@ export function useChatSession(options?: { skip?: boolean; autoConnect?: boolean
   const [unreadCount, setUnreadCount] = useState(0);
   const [isTyping, setIsTyping] = useState(false);
 
+  // Coalesce concurrent initialize calls (e.g. handleOpen + autoConnect effect
+  // firing in the same tick) onto a single in-flight promise. Prevents two
+  // POSTs racing the unique-active-conversation-per-user index.
+  const initInFlight = useRef<Promise<void> | null>(null);
+
   const supabase = createClient();
 
   // Generate or retrieve session ID
@@ -71,9 +76,16 @@ export function useChatSession(options?: { skip?: boolean; autoConnect?: boolean
       return;
     }
 
+    // If an init is already in-flight (e.g. handleOpen fired immediately and
+    // the autoConnect effect re-fires on the same tick), reuse that promise.
+    if (initInFlight.current) {
+      return initInFlight.current;
+    }
+
     setIsLoading(true);
     setError(null);
 
+    const run = (async () => {
     try {
       const sessionId = getSessionId();
 
@@ -149,7 +161,15 @@ export function useChatSession(options?: { skip?: boolean; autoConnect?: boolean
     } finally {
       setIsLoading(false);
     }
-  }, [chatSession.isInitialized, session, getSessionId, supabase]);
+    })();
+
+    initInFlight.current = run;
+    try {
+      await run;
+    } finally {
+      initInFlight.current = null;
+    }
+  }, [chatSession.isInitialized, session, getSessionId, supabase, status]);
 
   // Load messages for conversation using API route
   const loadMessages = useCallback(async (conversationId: string) => {


### PR DESCRIPTION
## Summary
- Chat opening fired three concurrent `/api/chat/initialize` POSTs (handleOpen, autoConnect effect, ChatWindow mount effect). All passed the `isInitialized` early-return before state propagated, all hit the partial unique index `idx_unique_active_conversation_per_user` on the loser's INSERT and surfaced as 500.
- Defense in depth: API now catches `23505` on conv insert and re-fetches the winning row (idempotent — also covers two-tab races); hook coalesces concurrent inits onto a single in-flight promise.
- Also locks `document.body.style.overflow` while `ChatWindow` is mounted so mobile swipes inside the fixed overlay don't bleed through and scroll the page underneath. Mirrors the existing modal pattern in the booking Layout.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] On mobile, open chat on `/course-rental` — the 500 toast should not appear, and swiping inside the chat should not move the page underneath
- [ ] Open chat in two tabs at once for the same logged-in user — both should resolve to the same conversation, no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)