### PR TITLE
fix(i18n): share NEXT_LOCALE cookie across len.golf subdomains

### DIFF
--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -7,6 +7,9 @@ export const routing = defineRouting({
   localeCookie: {
     name: 'NEXT_LOCALE',
     maxAge: 60 * 60 * 24 * 365, // 1 year
+    // Share across len.golf subdomains (booking.len.golf, www.len.golf)
+    // so language selection persists between the marketing site and booking.
+    domain: process.env.NODE_ENV === 'production' ? '.len.golf' : undefined,
   },
 });
 


### PR DESCRIPTION
## Summary
- Scope the `NEXT_LOCALE` cookie to `Domain=.len.golf` in production so language selection persists between `www.len.golf` ↔ `booking.len.golf`.
- Dev (localhost) keeps the cookie host-only (`undefined` domain), unchanged.

## Why
User reported: picking Japanese on `www.len.golf`, then navigating to `booking.len.golf`, reset back to English. Root cause: next-intl's `localeCookie` was set without a `Domain` attribute, so each subdomain got its own cookie and neither could read the other's.

## Paired change
Matching edit in the `lengolf-website` repo — both must ship together or the sharing doesn't work.

## Known caveat
Returning users who already have a host-only `NEXT_LOCALE` cookie will keep seeing their old behavior until it expires. Browsers send both cookies and precedence is undefined. Low-impact: they'll re-pick the language at most once.

## Test plan
- [ ] Staging: switch to `ja` on `www.len.golf` staging, navigate to `booking.len.golf` staging — booking page should render in Japanese
- [ ] DevTools: confirm `Set-Cookie: NEXT_LOCALE=ja; Domain=.len.golf` in response headers on both hosts
- [ ] Local dev: `NEXT_LOCALE` cookie still works (host-only on localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)