### PR TITLE
feat(clubs): clarify right-handed default and left-handed availability

### DIFF
--- a/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
+++ b/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
@@ -1556,6 +1556,7 @@ export function BookingDetails({
                     </table>
                   </div>
                   <p className="text-center text-xs text-gray-500 mt-2">{t('clubRentalStandardFreeNote')}</p>
+                  <p className="text-center text-xs text-gray-500 mt-1 italic">{t('clubRentalHandednessNote')}</p>
                 </div>
 
                 {/* Club Options - flex col on mobile, 3-col on desktop, all cards stretch to equal height */}

--- a/app/[locale]/course-rental/page.tsx
+++ b/app/[locale]/course-rental/page.tsx
@@ -333,6 +333,17 @@ export default function CourseRentalPage() {
               </span>
             </div>
 
+            {/* Handedness note */}
+            <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-xs sm:text-sm">
+              <p className="font-semibold text-green-800">All sets shown are right-handed</p>
+              <p className="mt-0.5 text-gray-700">
+                We have one left-handed Premium set available on request. Please contact us on{' '}
+                <a href="https://lin.ee/uxQpIXn" target="_blank" rel="noopener noreferrer" className="font-semibold text-green-700 underline">
+                  LINE @lengolf
+                </a>{' '}before booking to confirm availability.
+              </p>
+            </div>
+
             {setsLoading ? (
               <div className="flex justify-center py-12">
                 <div className="w-8 h-8 border-4 border-green-600 border-t-transparent rounded-full animate-spin" />

--- a/app/[locale]/golf-club-rental/page.tsx
+++ b/app/[locale]/golf-club-rental/page.tsx
@@ -397,6 +397,12 @@ export default function GolfClubRentalPage() {
               </Link>
             </div>
           </div>
+
+          {/* Handedness note */}
+          <div className="mx-auto mt-6 max-w-4xl rounded-lg border border-green-200 bg-green-50 px-4 sm:px-5 py-3 sm:py-4 text-sm">
+            <p className="font-semibold text-green-800">{t('sets.handednessNoteTitle')}</p>
+            <p className="mt-1 text-gray-700">{t('sets.handednessNote')}</p>
+          </div>
         </div>
 
         {/* Why Choose LENGOLF Section */}
@@ -465,6 +471,12 @@ export default function GolfClubRentalPage() {
                   {t('faq.q4Link')}
                 </Link>
                 {t('faq.q4BodyAfter')}
+              </p>
+            </div>
+            <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+              <h3 className="font-semibold text-gray-900 mb-1 sm:mb-2 text-sm sm:text-base">{t('faq.q5Title')}</h3>
+              <p className="text-xs sm:text-sm text-gray-700">
+                {t('faq.q5Body')}
               </p>
             </div>
           </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -255,6 +255,7 @@
       "clubRentalTablePremium": "Premium",
       "clubRentalTablePremiumPlus": "Premium+",
       "clubRentalStandardFreeNote": "Standard clubs are always free with any bay booking",
+      "clubRentalHandednessNote": "Premium sets shown are right-handed. Need a left-handed Premium set? Contact us on LINE @lengolf to reserve.",
       "clubRentalStandardCardTitle": "Standard Set",
       "clubRentalStandardCardSubtitle": "Quality house set — great for casual play",
       "clubRentalStandardCardSubtitle2": "House Set — Men's & Ladies'",
@@ -735,7 +736,9 @@
       "premiumPlusItem2": "Irons 5–PW — Tungsten weighted",
       "premiumPlusItem3": "Jaws Raw Wedges (52°, 56°)",
       "premiumPlusItem4": "Odyssey Putter + Callaway camo bag",
-      "premiumPlusCta": "Book with Premium+ Clubs"
+      "premiumPlusCta": "Book with Premium+ Clubs",
+      "handednessNoteTitle": "Right-handed by default",
+      "handednessNote": "All Premium and Premium+ sets shown are right-handed. Free standard left-handed clubs are available with every bay booking, and we keep one left-handed Premium rental set available on request — contact us on LINE @lengolf to reserve."
     },
     "why": {
       "heading": "Why Choose LENGOLF Golf Club Rental?",
@@ -759,7 +762,9 @@
       "q4Title": "Can I use the rental clubs outside of LENGOLF?",
       "q4BodyBefore": "The hourly rates on this page are for in-bay simulator use only. For taking clubs to a Bangkok golf course (daily rates from ฿1,200 with delivery available), see our ",
       "q4Link": "Golf Course Club Rental",
-      "q4BodyAfter": " page."
+      "q4BodyAfter": " page.",
+      "q5Title": "Do you have left-handed clubs?",
+      "q5Body": "Yes — free standard left-handed clubs are included with any bay booking. We also have one left-handed Premium rental set available on request, charged at our regular Premium rates. The Premium+ Paradym is right-handed only. Message us on LINE @lengolf to reserve a left-handed Premium set in advance."
     },
     "cta": {
       "heading": "Ready to Play with Premium Clubs?",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -255,6 +255,7 @@
       "clubRentalTablePremium": "プレミアム",
       "clubRentalTablePremiumPlus": "プレミアム+",
       "clubRentalStandardFreeNote": "スタンダードクラブはすべてのベイ予約で無料",
+      "clubRentalHandednessNote": "表示されているプレミアムセットは右利き用です。左利き用のプレミアムセットをご希望ですか？LINE @lengolfまでご連絡ください。",
       "clubRentalStandardCardTitle": "スタンダードセット",
       "clubRentalStandardCardSubtitle": "高品質ハウスセット — カジュアルなプレーに最適",
       "clubRentalStandardCardSubtitle2": "ハウスセット — メンズ＆レディース",
@@ -735,7 +736,9 @@
       "premiumPlusItem2": "アイアン 5–PW — タングステンウェイト搭載",
       "premiumPlusItem3": "Jaws Raw ウェッジ (52°、56°)",
       "premiumPlusItem4": "Odyssey パター + Callaway カモバッグ",
-      "premiumPlusCta": "プレミアム+ クラブで予約"
+      "premiumPlusCta": "プレミアム+ クラブで予約",
+      "handednessNoteTitle": "表示はすべて右利き用",
+      "handednessNote": "表示されているプレミアムおよびプレミアム+セットはすべて右利き用です。スタンダードの左利き用クラブはベイご予約時に無料でご利用いただけます。また、左利き用プレミアムレンタルセットを1セットご用意しておりますので、ご希望の方はLINE @lengolfまでご連絡ください。"
     },
     "why": {
       "heading": "LENGOLF ゴルフクラブレンタルを選ぶ理由",
@@ -759,7 +762,9 @@
       "q4Title": "レンタルクラブを LENGOLF 外で使用できますか？",
       "q4BodyBefore": "このページの時間料金はベイ内シミュレーター利用のみ対象です。バンコクのゴルフコースへのクラブ持ち出し（฿1,200〜の日料金、配送あり）については、",
       "q4Link": "ゴルフコース用クラブレンタル",
-      "q4BodyAfter": " ページをご覧ください。"
+      "q4BodyAfter": " ページをご覧ください。",
+      "q5Title": "左利き用のクラブはありますか？",
+      "q5Body": "はい — スタンダードの左利き用クラブはベイ予約時に無料でご利用いただけます。さらに左利き用プレミアムレンタルセットを1セットご用意しており、通常のプレミアム料金でリクエスト可能です。プレミアム+ Paradymは右利き専用です。LINE @lengolfまで事前にご連絡いただければ、左利き用プレミアムセットをお取り置きいたします。"
     },
     "cta": {
       "heading": "プレミアムクラブでプレーする準備はできましたか？",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -255,6 +255,7 @@
       "clubRentalTablePremium": "프리미엄",
       "clubRentalTablePremiumPlus": "프리미엄+",
       "clubRentalStandardFreeNote": "스탠다드 클럽은 모든 베이 예약에 무료로 제공됩니다",
+      "clubRentalHandednessNote": "표시된 프리미엄 세트는 오른손잡이용입니다. 왼손잡이용 프리미엄 세트가 필요하신가요? LINE @lengolf으로 연락 주세요.",
       "clubRentalStandardCardTitle": "스탠다드 세트",
       "clubRentalStandardCardSubtitle": "고품질 하우스 세트 — 캐주얼한 플레이에 적합",
       "clubRentalStandardCardSubtitle2": "하우스 세트 — 남성용 & 여성용",
@@ -735,7 +736,9 @@
       "premiumPlusItem2": "아이언 5–PW — 텅스텐 웨이트",
       "premiumPlusItem3": "Jaws Raw 웨지 (52°, 56°)",
       "premiumPlusItem4": "Odyssey 퍼터 + Callaway 카모 백",
-      "premiumPlusCta": "프리미엄+ 클럽으로 예약"
+      "premiumPlusCta": "프리미엄+ 클럽으로 예약",
+      "handednessNoteTitle": "표시된 세트는 모두 오른손잡이용",
+      "handednessNote": "표시된 모든 프리미엄 및 프리미엄+ 세트는 오른손잡이용입니다. 베이 예약 시 표준 왼손잡이용 클럽은 무료로 이용 가능합니다. 또한 왼손잡이용 프리미엄 렌탈 세트가 1개 있어 요청 시 이용 가능합니다 — LINE @lengolf으로 연락하여 예약해 주세요."
     },
     "why": {
       "heading": "왜 LENGOLF 골프 클럽 렌탈을 선택해야 할까요?",
@@ -759,7 +762,9 @@
       "q4Title": "렌탈 클럽을 LENGOLF 외부에서 사용할 수 있나요?",
       "q4BodyBefore": "이 페이지의 시간 요금은 베이 시뮬레이터 사용에만 해당됩니다. 방콕 골프 코스로 클럽을 가져가시려면(฿1,200부터 일일 요금, 배송 가능), ",
       "q4Link": "골프 코스 클럽 렌탈",
-      "q4BodyAfter": " 페이지를 참조해 주세요."
+      "q4BodyAfter": " 페이지를 참조해 주세요.",
+      "q5Title": "왼손잡이용 클럽이 있나요?",
+      "q5Body": "네 — 베이 예약 시 표준 왼손잡이용 클럽은 무료로 제공됩니다. 또한 왼손잡이용 프리미엄 렌탈 세트가 1개 있으며, 일반 프리미엄 요금으로 요청 가능합니다. 프리미엄+ Paradym은 오른손잡이 전용입니다. LINE @lengolf으로 미리 연락하여 왼손잡이용 프리미엄 세트를 예약해 주세요."
     },
     "cta": {
       "heading": "프리미엄 클럽으로 플레이할 준비가 되셨나요?",

--- a/messages/th.json
+++ b/messages/th.json
@@ -255,6 +255,7 @@
       "clubRentalTablePremium": "พรีเมียม",
       "clubRentalTablePremiumPlus": "พรีเมียม+",
       "clubRentalStandardFreeNote": "ไม้มาตรฐานฟรีกับทุกการจองเบย์",
+      "clubRentalHandednessNote": "เซ็ต Premium ที่แสดงเป็นไม้สำหรับมือขวา ต้องการเซ็ต Premium มือซ้าย? ติดต่อเราทาง LINE @lengolf เพื่อสำรอง",
       "clubRentalStandardCardTitle": "ชุดมาตรฐาน",
       "clubRentalStandardCardSubtitle": "ชุดของร้านคุณภาพดี — เหมาะกับการเล่นทั่วไป",
       "clubRentalStandardCardSubtitle2": "ชุดของร้าน — ผู้ชายและผู้หญิง",
@@ -735,7 +736,9 @@
       "premiumPlusItem2": "ไอรอน 5–PW — ถ่วงน้ำหนักทังสเตน",
       "premiumPlusItem3": "Jaws Raw Wedges (52°, 56°)",
       "premiumPlusItem4": "พัตเตอร์ Odyssey + ถุงลายพราง Callaway",
-      "premiumPlusCta": "จองพร้อมไม้พรีเมียม+"
+      "premiumPlusCta": "จองพร้อมไม้พรีเมียม+",
+      "handednessNoteTitle": "ไม้แสดงทั้งหมดสำหรับมือขวา",
+      "handednessNote": "เซ็ต Premium และ Premium+ ที่แสดงทั้งหมดเป็นไม้สำหรับมือขวา ไม้กอล์ฟมาตรฐานสำหรับมือซ้ายมีให้บริการฟรีทุกการจองเบย์ และเรามีเซ็ต Premium มือซ้าย 1 ชุดให้เช่าตามคำขอ — ติดต่อเราทาง LINE @lengolf เพื่อสำรอง"
     },
     "why": {
       "heading": "ทำไมเลือกเช่าไม้กอล์ฟ LENGOLF?",
@@ -759,7 +762,9 @@
       "q4Title": "สามารถใช้ไม้เช่านอก LENGOLF ได้หรือไม่?",
       "q4BodyBefore": "ราคารายชั่วโมงในหน้านี้สำหรับใช้ในเบย์ซิมูเลเตอร์เท่านั้น สำหรับการนำไม้ไปสนามกอล์ฟในกรุงเทพฯ (ราคารายวันเริ่มต้น ฿1,200 พร้อมบริการจัดส่ง) โปรดดูที่หน้า ",
       "q4Link": "เช่าไม้กอล์ฟสำหรับสนาม",
-      "q4BodyAfter": " ของเรา"
+      "q4BodyAfter": " ของเรา",
+      "q5Title": "มีไม้กอล์ฟสำหรับมือซ้ายไหม?",
+      "q5Body": "มีค่ะ — ไม้กอล์ฟมาตรฐานมือซ้ายฟรีทุกการจองเบย์ และเรามีเซ็ต Premium มือซ้าย 1 ชุดให้เช่าตามคำขอ ราคาเดียวกับ Premium ปกติ ส่วน Premium+ Paradym มีเฉพาะสำหรับมือขวาเท่านั้น ส่งข้อความทาง LINE @lengolf เพื่อสำรองเซ็ต Premium มือซ้ายล่วงหน้า"
     },
     "cta": {
       "heading": "พร้อมเล่นกับไม้พรีเมียมแล้วหรือยัง?",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -255,6 +255,7 @@
       "clubRentalTablePremium": "高级",
       "clubRentalTablePremiumPlus": "高级+",
       "clubRentalStandardFreeNote": "标准球杆在任何球位预约中均免费提供",
+      "clubRentalHandednessNote": "展示的 Premium 套装为右手用。需要左手 Premium 套装？请通过 LINE @lengolf 联系我们。",
       "clubRentalStandardCardTitle": "标准套装",
       "clubRentalStandardCardSubtitle": "高品质店内套装 — 适合休闲游玩",
       "clubRentalStandardCardSubtitle2": "店内套装 — 男士与女士",
@@ -735,7 +736,9 @@
       "premiumPlusItem2": "铁杆 5–PW — 钨钢配重",
       "premiumPlusItem3": "Jaws Raw 挖起杆 (52°、56°)",
       "premiumPlusItem4": "Odyssey 推杆 + Callaway 迷彩包",
-      "premiumPlusCta": "用高级+ 球杆预约"
+      "premiumPlusCta": "用高级+ 球杆预约",
+      "handednessNoteTitle": "展示球杆均为右手用",
+      "handednessNote": "展示的所有 Premium 与 Premium+ 套装均为右手用。每次球位预订均免费提供标准左手球杆。我们另有一套左手专用 Premium 租赁球杆可应要求租用 — 请通过 LINE @lengolf 联系我们预订。"
     },
     "why": {
       "heading": "为什么选择 LENGOLF 高尔夫球杆租赁？",
@@ -759,7 +762,9 @@
       "q4Title": "我可以在 LENGOLF 之外使用租赁球杆吗？",
       "q4BodyBefore": "本页面的小时费率仅限球位模拟器使用。如要将球杆带去曼谷高尔夫球场（每日费率从 ฿1,200 起，提供配送），请参阅我们的 ",
       "q4Link": "高尔夫球场球杆租赁",
-      "q4BodyAfter": " 页面。"
+      "q4BodyAfter": " 页面。",
+      "q5Title": "你们有左手球杆吗？",
+      "q5Body": "有的 — 每次球位预订均免费提供标准左手球杆。我们另有一套左手专用 Premium 租赁球杆可应要求租用，价格与 Premium 标准价相同。Premium+ Paradym 仅限右手用。请提前通过 LINE @lengolf 联系我们预订左手 Premium 套装。"
     },
     "cta": {
       "heading": "准备好用高级球杆开打了吗？",


### PR DESCRIPTION
## Summary
- All Premium and Premium+ rental sets shown to customers are right-handed. Adds a handedness callout on the /golf-club-rental marketing page tier section, a new FAQ entry, and a small note inside the Premium club selection modal in the bay-booking flow (\`BookingDetails.tsx\`).
- Adds an English-only handedness note on /course-rental Step 2 (set selection). That page is currently entirely hardcoded English; full translation is a planned follow-up task.
- All 5 locales updated for translated surfaces (en/th/ja/ko/zh).

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [ ] Visual check of /golf-club-rental tier section + new FAQ in all 5 locales
- [ ] Visual check of Premium club selection modal note during bay booking flow
- [ ] Visual check of /course-rental Step 2 set-selection note (English only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)