### PR TITLE
fix(bookings): stop showing B1G1 to returning customers in cost preview

### DIFF
--- a/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
+++ b/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
@@ -207,25 +207,22 @@ export function BookingDetails({
     let cancelled = false;
     async function fetchCostData() {
       try {
-        const [pkgRes, bookingsRes] = await Promise.all([
+        // Eligibility (isNewCustomer) is computed phone-aware in the effect
+        // watching `phoneNumber`; we deliberately do NOT call the legacy
+        // profile-only /api/user/has-bookings here because it can race the
+        // phone-aware fetch (slower of the two wins) and re-introduce the
+        // bait-and-switch bug.
+        const [pkgRes, promoRes] = await Promise.all([
           fetch('/api/user/active-packages'),
-          fetch('/api/user/has-bookings'),
+          fetch('/api/promotions/applicable'),
         ]);
         if (cancelled) return;
 
         const pkgData = await pkgRes.json();
-        const bookingsData = await bookingsRes.json();
+        const promoData = await promoRes.json();
 
         setHasActivePackage(pkgData.hasPackage ?? false);
         setPackageDisplayName(pkgData.packageDisplayName);
-
-        const newCust = bookingsData.hasBookings === false;
-        setIsNewCustomer(newCust);
-
-        // Fetch applicable promotions
-        const promoRes = await fetch('/api/promotions/applicable');
-        if (cancelled) return;
-        const promoData = await promoRes.json();
         setApplicablePromotions(promoData.promotions ?? []);
       } catch (err) {
         console.error('[CostEstimate] Failed to fetch cost data:', err);
@@ -243,25 +240,31 @@ export function BookingDetails({
   // through a fresh auth profile (or guest flow) is correctly identified
   // before they confirm — preventing B1G1 from being shown to returning
   // customers in the cost preview.
+  //
+  // Uses a `cancelled` flag rather than AbortController because aborting
+  // the fetch doesn't stop a response that has already arrived from
+  // resolving its .then chain — meaning a slower in-flight call could
+  // overwrite a faster newer one. The flag guarantees only the latest
+  // invocation can call setState.
   useEffect(() => {
     const phone = phoneNumber?.trim();
     if (!phone || phone.length < 8) return;
-    const controller = new AbortController();
+    let cancelled = false;
     const timer = setTimeout(() => {
-      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`, {
-        signal: controller.signal,
-      })
+      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`)
         .then(res => res.json())
-        .then(hbData => setIsNewCustomer(hbData.hasBookings === false))
+        .then(hbData => {
+          if (cancelled) return;
+          setIsNewCustomer(hbData.hasBookings === false);
+        })
         .catch((err) => {
-          if (err?.name !== 'AbortError') {
-            // Conservative: leave whatever state we had
-          }
+          if (cancelled) return;
+          console.warn('[has-bookings] phone-aware fetch failed:', err);
         });
     }, 400);
     return () => {
+      cancelled = true;
       clearTimeout(timer);
-      controller.abort();
     };
   }, [phoneNumber]);
 

--- a/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
+++ b/app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx
@@ -237,6 +237,34 @@ export function BookingDetails({
     return () => { cancelled = true; };
   }, [status]);
 
+  // Re-evaluate new-customer status whenever the phone field changes.
+  // Uses the canonical public.is_phone_new_customer predicate via
+  // /api/user/has-bookings?phone=… so that an existing customer logging in
+  // through a fresh auth profile (or guest flow) is correctly identified
+  // before they confirm — preventing B1G1 from being shown to returning
+  // customers in the cost preview.
+  useEffect(() => {
+    const phone = phoneNumber?.trim();
+    if (!phone || phone.length < 8) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`, {
+        signal: controller.signal,
+      })
+        .then(res => res.json())
+        .then(hbData => setIsNewCustomer(hbData.hasBookings === false))
+        .catch((err) => {
+          if (err?.name !== 'AbortError') {
+            // Conservative: leave whatever state we had
+          }
+        });
+    }, 400);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [phoneNumber]);
+
   // Helper function to get bay availability for a specific duration
   const getBayAvailabilityForDuration = useCallback((dur: number) => {
     if (!slotData?.bayAvailabilityByDuration) {

--- a/app/api/user/has-bookings/route.ts
+++ b/app/api/user/has-bookings/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/app/api/auth/options';
 import { createAdminClient } from '@/utils/supabase/admin';
@@ -12,10 +12,43 @@ interface HasBookingsSession extends NextAuthSession {
   user: HasBookingsSessionUser;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions) as HasBookingsSession | null;
+  const phone = request.nextUrl.searchParams.get('phone');
 
-  // If not authenticated, return false (treat as new customer)
+  // Phone-based path: works even without an authenticated session and uses the
+  // same canonical predicate (public.is_phone_new_customer) that the
+  // check_new_customer trigger uses to set bookings.is_new_customer at insert time.
+  if (phone) {
+    const supabase = createAdminClient();
+    const customerId = session?.user?.id
+      ? (await supabase
+          .from('profiles')
+          .select('customer_id')
+          .eq('id', session.user.id)
+          .maybeSingle()
+        ).data?.customer_id ?? null
+      : null;
+
+    const { data: isNew, error } = await supabase.rpc('is_phone_new_customer', {
+      p_phone: phone,
+      p_customer_id: customerId,
+    });
+
+    if (error) {
+      console.error('[Has Bookings API] is_phone_new_customer RPC error:', error);
+      // On error, assume user has bookings so we don't incorrectly show promos
+      return NextResponse.json({ hasBookings: true });
+    }
+
+    // RPC returns NULL when phone is unusable and no customer_id signal exists.
+    // Default to "treat as new" in that case so we don't block legitimate B1G1
+    // for genuine new customers who haven't typed enough yet.
+    const hasBookings = isNew === false;
+    return NextResponse.json({ hasBookings });
+  }
+
+  // Profile-only path (legacy callers): unauthenticated → treat as new
   if (!session?.user?.id) {
     return NextResponse.json({ hasBookings: false });
   }

--- a/app/api/user/has-bookings/route.ts
+++ b/app/api/user/has-bookings/route.ts
@@ -16,19 +16,27 @@ export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions) as HasBookingsSession | null;
   const phone = request.nextUrl.searchParams.get('phone');
 
-  // Phone-based path: works even without an authenticated session and uses the
-  // same canonical predicate (public.is_phone_new_customer) that the
-  // check_new_customer trigger uses to set bookings.is_new_customer at insert time.
+  // Both paths require a session. The phone-based path in particular MUST be
+  // gated: without auth it would be an enumeration oracle on customer
+  // existence (anon could probe arbitrary phone numbers and learn whether
+  // each has any prior bookings or POS sales). All legitimate callers
+  // (LIFF, NextAuth web flow, guest provider) have a session by the time
+  // they reach the cost preview, so requiring one is non-disruptive.
+  if (!session?.user?.id) {
+    return NextResponse.json({ hasBookings: false });
+  }
+
+  // Phone-based path uses the canonical predicate (public.is_phone_new_customer)
+  // that the check_new_customer trigger uses to set bookings.is_new_customer
+  // at insert time — single source of truth.
   if (phone) {
     const supabase = createAdminClient();
-    const customerId = session?.user?.id
-      ? (await supabase
-          .from('profiles')
-          .select('customer_id')
-          .eq('id', session.user.id)
-          .maybeSingle()
-        ).data?.customer_id ?? null
-      : null;
+    const { data: profileData } = await supabase
+      .from('profiles')
+      .select('customer_id')
+      .eq('id', session.user.id)
+      .maybeSingle();
+    const customerId = profileData?.customer_id ?? null;
 
     const { data: isNew, error } = await supabase.rpc('is_phone_new_customer', {
       p_phone: phone,
@@ -46,11 +54,6 @@ export async function GET(request: NextRequest) {
     // for genuine new customers who haven't typed enough yet.
     const hasBookings = isNew === false;
     return NextResponse.json({ hasBookings });
-  }
-
-  // Profile-only path (legacy callers): unauthenticated → treat as new
-  if (!session?.user?.id) {
-    return NextResponse.json({ hasBookings: false });
   }
 
   const profileId = session.user.id;

--- a/app/liff/booking/page.tsx
+++ b/app/liff/booking/page.tsx
@@ -105,25 +105,31 @@ export default function LiffBookingPage() {
   // through a fresh LINE LIFF profile (or any unlinked auth) is correctly
   // identified before they confirm — preventing B1G1 from being shown to
   // returning customers in the cost preview.
+  //
+  // Uses a `cancelled` flag rather than AbortController because aborting
+  // the fetch doesn't stop a response that has already arrived from
+  // resolving its .then chain — meaning a slower in-flight call could
+  // overwrite a faster newer one. The flag pattern guarantees only the
+  // latest invocation can call setState.
   useEffect(() => {
     const phone = formData.phone?.trim();
     if (!phone || phone.length < 8) return;
-    const controller = new AbortController();
+    let cancelled = false;
     const timer = setTimeout(() => {
-      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`, {
-        signal: controller.signal,
-      })
+      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`)
         .then(res => res.json())
-        .then(hbData => setIsNewCustomer(hbData.hasBookings === false))
+        .then(hbData => {
+          if (cancelled) return;
+          setIsNewCustomer(hbData.hasBookings === false);
+        })
         .catch((err) => {
-          if (err?.name !== 'AbortError') {
-            // Conservative: leave whatever state we had
-          }
+          if (cancelled) return;
+          console.warn('[has-bookings] phone-aware fetch failed:', err);
         });
     }, 400);
     return () => {
+      cancelled = true;
       clearTimeout(timer);
-      controller.abort();
     };
   }, [formData.phone]);
 
@@ -213,11 +219,13 @@ export default function LiffBookingPage() {
       // Always proceed to booking - customer matching happens at booking time
       setViewState('booking');
 
-      // Check if new customer for promotions (non-blocking)
-      fetch('/api/user/has-bookings')
-        .then(res => res.json())
-        .then(hbData => setIsNewCustomer(hbData.hasBookings === false))
-        .catch(() => setIsNewCustomer(false));
+      // Promotions are static — fetch once on mount.
+      // Eligibility (isNewCustomer) is computed phone-aware in the effect
+      // watching formData.phone; we deliberately do NOT call the legacy
+      // profile-only /api/user/has-bookings here because it can race the
+      // phone-aware fetch (slower of the two wins) and re-introduce the
+      // bait-and-switch bug. The trigger-set isNewCustomer on the booking
+      // row is the authoritative value at confirmation time.
       fetch('/api/promotions/applicable')
         .then(res => res.json())
         .then(promoData => setApplicablePromotions(promoData.promotions ?? []))

--- a/app/liff/booking/page.tsx
+++ b/app/liff/booking/page.tsx
@@ -25,6 +25,11 @@ interface BookingResult {
   bookingId: string;
   bay: string;
   bayDisplayName: string;
+  // Authoritative new-customer flag from the server (set by the
+  // check_new_customer trigger when the booking row was inserted). Used by
+  // the success screen so the post-confirm cost matches the DB row, not
+  // whatever stale value the pre-confirm preview had.
+  isNewCustomer: boolean;
 }
 
 interface UserDataResponse {
@@ -93,6 +98,34 @@ export default function LiffBookingPage() {
     setLanguage(resolveLanguage());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Re-evaluate new-customer status whenever the phone field changes.
+  // Uses the canonical public.is_phone_new_customer predicate via
+  // /api/user/has-bookings?phone=… so that an existing customer logging in
+  // through a fresh LINE LIFF profile (or any unlinked auth) is correctly
+  // identified before they confirm — preventing B1G1 from being shown to
+  // returning customers in the cost preview.
+  useEffect(() => {
+    const phone = formData.phone?.trim();
+    if (!phone || phone.length < 8) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      fetch(`/api/user/has-bookings?phone=${encodeURIComponent(phone)}`, {
+        signal: controller.signal,
+      })
+        .then(res => res.json())
+        .then(hbData => setIsNewCustomer(hbData.hasBookings === false))
+        .catch((err) => {
+          if (err?.name !== 'AbortError') {
+            // Conservative: leave whatever state we had
+          }
+        });
+    }, 400);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [formData.phone]);
 
   const initializeLiff = async () => {
     try {
@@ -389,7 +422,12 @@ export default function LiffBookingPage() {
       setBookingResult({
         bookingId: result.bookingId,
         bay: result.bay,
-        bayDisplayName: result.bayDisplayName
+        bayDisplayName: result.bayDisplayName,
+        // Pull the trigger-set authoritative flag from the booking row that
+        // the API echoes back. Used by the success-screen cost calc instead
+        // of the local isNewCustomer state, which can be stale (it was set
+        // earlier in the session before customer-matching ran).
+        isNewCustomer: result.booking?.is_new_customer === true,
       });
 
       setViewState('success');
@@ -503,7 +541,12 @@ export default function LiffBookingPage() {
       return { en: 'Social Bay', th: 'Social Bay', ja: 'ソーシャルベイ', zh: 'Social Bay' }[language];
     };
 
-    // Compute cost breakdown for success screen (same as pre-confirm)
+    // Compute cost breakdown for success screen.
+    // Use the server-authoritative isNewCustomer from the booking row
+    // (set by the check_new_customer trigger via is_phone_new_customer),
+    // NOT the local state — local state may have been computed before
+    // customer-matching ran and could falsely show B1G1 to a returning
+    // customer logging in via a fresh auth profile.
     const successCostBreakdown = calculateCost({
       date: format(selectedDate, 'yyyy-MM-dd'),
       startTime: selectedSlot.time,
@@ -512,7 +555,7 @@ export default function LiffBookingPage() {
       playFoodPackageId: formData.playFoodPackage?.id ?? null,
       hasActivePackage: !!activePackage,
       packageDisplayName: activePackage?.displayName,
-      isNewCustomer,
+      isNewCustomer: bookingResult.isNewCustomer,
       applicablePromotions,
     });
 

--- a/supabase/migrations/20260427000000_extract_is_phone_new_customer_helper.sql
+++ b/supabase/migrations/20260427000000_extract_is_phone_new_customer_helper.sql
@@ -1,0 +1,109 @@
+-- Extract the canonical "is this customer new?" predicate from the
+-- check_new_customer() trigger into a reusable function.
+-- This becomes the single source of truth used by:
+--   * the BEFORE INSERT/UPDATE trigger on public.bookings (refactored below)
+--   * /api/user/has-bookings (booking-app eligibility preview)
+--   * any future caller that needs the same answer
+--
+-- Logic mirrors the prior trigger exactly: a phone is "new" iff
+--   1. no prior CONFIRMED booking with same normalize_phone_number(phone)
+--   2. no pos.lengolf_sales row with same normalize_phone_number(customer_phone_number)
+--   3. no prior CONFIRMED booking with same customer_id (when customer_id provided)
+
+CREATE OR REPLACE FUNCTION public.is_phone_new_customer(
+  p_phone text,
+  p_customer_id uuid DEFAULT NULL,
+  p_exclude_booking_id text DEFAULT NULL
+) RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'pg_catalog', 'public', 'extensions'
+AS $$
+DECLARE
+  v_normalized_phone text;
+BEGIN
+  -- Validate phone the same way the original trigger did
+  IF p_phone IS NULL
+     OR LENGTH(TRIM(p_phone)) < 8
+     OR p_phone !~ '^[0-9+\-\s\(\)]+$'
+     OR p_phone = '-'
+     OR p_phone LIKE '0000%' THEN
+    -- Phone unusable: fall back to customer_id-only check if available
+    IF p_customer_id IS NOT NULL THEN
+      RETURN NOT EXISTS (
+        SELECT 1 FROM public.bookings
+        WHERE customer_id = p_customer_id
+          AND (p_exclude_booking_id IS NULL OR id != p_exclude_booking_id)
+          AND status = 'confirmed'
+      );
+    END IF;
+    -- No usable signal at all: matches the original trigger's fallthrough
+    -- (which left is_new_customer untouched for the row). For preview callers
+    -- the safest answer is "we don't know, treat as new" — but we return NULL
+    -- here and let callers decide. Trigger wrapper handles its own default.
+    RETURN NULL;
+  END IF;
+
+  v_normalized_phone := normalize_phone_number(p_phone);
+  IF v_normalized_phone IS NULL OR LENGTH(v_normalized_phone) < 8 THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN NOT EXISTS (
+      -- (1) Prior confirmed booking with same normalized phone
+      SELECT 1 FROM public.bookings
+      WHERE normalize_phone_number(phone_number) = v_normalized_phone
+        AND (p_exclude_booking_id IS NULL OR id != p_exclude_booking_id)
+        AND status = 'confirmed'
+        AND phone_number IS NOT NULL
+        AND LENGTH(TRIM(phone_number)) >= 8
+        AND phone_number != '-'
+        AND phone_number NOT LIKE '0000%'
+    ) AND NOT EXISTS (
+      -- (2) POS sales history with same normalized phone
+      SELECT 1 FROM pos.lengolf_sales
+      WHERE normalize_phone_number(customer_phone_number) = v_normalized_phone
+        AND customer_phone_number IS NOT NULL
+        AND LENGTH(TRIM(customer_phone_number)) >= 8
+        AND customer_phone_number != '-'
+        AND customer_phone_number NOT LIKE '0000%'
+    ) AND NOT EXISTS (
+      -- (3) Prior confirmed booking under same customer_id
+      SELECT 1 FROM public.bookings
+      WHERE customer_id = p_customer_id
+        AND p_customer_id IS NOT NULL
+        AND (p_exclude_booking_id IS NULL OR id != p_exclude_booking_id)
+        AND status = 'confirmed'
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.is_phone_new_customer(text, uuid, text) IS
+  'Canonical predicate for whether a phone (and optional customer_id) belongs to a new customer. Used by the check_new_customer trigger and by booking-app eligibility-preview endpoints. Returns NULL when phone is unusable AND customer_id is NULL — caller decides default.';
+
+-- Allow the booking-app server (service_role) and any authenticated server
+-- contexts to call this. Anon stays blocked.
+GRANT EXECUTE ON FUNCTION public.is_phone_new_customer(text, uuid, text) TO service_role, authenticated;
+
+-- Refactor the trigger to be a thin wrapper around the new helper.
+-- Behavior is preserved: when the helper returns NULL (no usable signal),
+-- we leave NEW.is_new_customer untouched, matching the prior trigger.
+CREATE OR REPLACE FUNCTION public.check_new_customer()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'pg_catalog', 'public', 'extensions'
+AS $$
+DECLARE
+  v_is_new boolean;
+BEGIN
+  v_is_new := public.is_phone_new_customer(
+    NEW.phone_number,
+    NEW.customer_id,
+    NEW.id
+  );
+  IF v_is_new IS NOT NULL THEN
+    NEW.is_new_customer := v_is_new;
+  END IF;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

A returning customer who received the welcome-back B1G1 LINE message opened the LIFF link, entered their existing phone, and saw `-฿950` (B1G1) on both the pre-confirm preview and the post-confirm "Booking Confirmed!" screen. The booking row was correct (`is_new_customer = false`, `customer_id` linked); only the UI was wrong.

**Root cause (two layers):**
- Pre-confirm preview asked `/api/user/has-bookings` which is profile-scoped (NextAuth `user_id` / `profile.customer_id`). A fresh LIFF login has no `customer_id` linkage yet — `/api/liff/booking/user` defers customer matching to booking-create time — so the count returned 0 and `isNewCustomer` went true.
- LIFF success screen recomputed cost from stale local React state instead of reading the just-saved booking row.

**Strategy:** reuse the canonical predicate already at the heart of `check_new_customer()` — the `BEFORE INSERT/UPDATE` trigger on `public.bookings` that every booking (staff app, website, LIFF, anywhere) runs through. Extract it into a function we can call BEFORE the row is written.

## Changes

**Migration** (`supabase/migrations/20260427000000_…sql`)
- New `public.is_phone_new_customer(phone, customer_id, exclude_booking_id) → boolean`. Tests prior confirmed booking by normalized phone, POS sales history by normalized phone, and prior booking by `customer_id`.
- `check_new_customer` trigger refactored to a thin wrapper. Behavior preserved.

**API**
- [`app/api/user/has-bookings/route.ts`](https://github.com/david2928/lengolf-booking-new/blob/fix/b1g1-existing-customer-leak/app/api/user/has-bookings/route.ts) — accepts optional `?phone=`; calls the new RPC. Legacy no-phone callers unchanged.

**Frontend**
- [`app/liff/booking/page.tsx`](https://github.com/david2928/lengolf-booking-new/blob/fix/b1g1-existing-customer-leak/app/liff/booking/page.tsx) — debounced (~400ms) refetch of `has-bookings` on phone change; `BookingResult` now carries `isNewCustomer` from the server-echoed booking row; success screen uses that authoritative value.
- [`app/[locale]/(features)/bookings/components/booking/steps/BookingDetails.tsx`](https://github.com/david2928/lengolf-booking-new/blob/fix/b1g1-existing-customer-leak/app/%5Blocale%5D/(features)/bookings/components/booking/steps/BookingDetails.tsx) — same debounced refetch on phone change.

**Bonus accuracy:** the canonical predicate also catches walk-ins with POS purchase history but no prior bookings — the prior phone-only `customers`-table lookup in `findOrCreateCustomer` would have missed them.

## Test plan

- [x] Migration sanity SQL: Peter's phone (both formats) → `false`; fresh phone → `true`; POS-only phone → `false`; `NULL`+customer_id → `false`; `NULL` alone → `null`.
- [x] Trigger refactor: `pg_get_functiondef` confirms wrapper installed.
- [x] API end-to-end (curl) on dev server: all phone scenarios return correct `hasBookings`.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] Page compilation: `/api/user/has-bookings`, `/liff/booking`, `/[locale]/bookings` all compiled, HTTP 200.
- [ ] Manual UI walk-through: open LIFF link with returning customer's phone — confirm B1G1 disappears from preview within ~400ms of entering phone, total = ฿1,900 on success screen.
- [ ] Manual UI walk-through: open LIFF link with brand-new phone — confirm B1G1 still appears in both preview and success screen, booking row's `is_new_customer = true`.

## Out of scope

- Welcome-back LINE message wording.
- Email-based customer matching (currently phone-only in `findOrCreateCustomer`).
- The booking-create API response shape (already returns the full booking row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)