### PR TITLE
fix(course-rental): await LINE + email notifications

### DIFF
--- a/app/api/clubs/reserve/route.ts
+++ b/app/api/clubs/reserve/route.ts
@@ -276,29 +276,33 @@ export async function POST(request: NextRequest) {
       }
       const emailLocale = resolveEmailLocale(resolvedLanguage);
 
-      sendCourseRentalConfirmationEmail({
-        customerName: customer_name,
-        email: customer_email,
-        rentalCode,
-        clubSetName: clubSet.name,
-        clubSetTier: clubSet.tier,
-        clubSetGender: clubSet.gender,
-        startDate: start_date,
-        endDate: end_date,
-        durationDays: duration_days || 1,
-        deliveryRequested: delivery_requested,
-        deliveryAddress: delivery_address,
-        deliveryTime: [
-          delivery_time ? `${delivery_requested ? 'Delivery' : 'Pickup'}: ${delivery_time}` : '',
-          return_time ? `Return: ${return_time}` : '',
-        ].filter(Boolean).join(', ') || undefined,
-        addOns: validatedAddOns.map((a: ClubRentalAddOn) => ({ label: a.label, price: a.price })),
-        rentalPrice: rental_price,
-        deliveryFee: delivery_fee,
-        totalPrice: total_price,
-        notes: customerNotes || undefined,
-        language: emailLocale,
-      }).catch(err => console.error('[ClubReserve] Email send error:', err));
+      try {
+        await sendCourseRentalConfirmationEmail({
+          customerName: customer_name,
+          email: customer_email,
+          rentalCode,
+          clubSetName: clubSet.name,
+          clubSetTier: clubSet.tier,
+          clubSetGender: clubSet.gender,
+          startDate: start_date,
+          endDate: end_date,
+          durationDays: duration_days || 1,
+          deliveryRequested: delivery_requested,
+          deliveryAddress: delivery_address,
+          deliveryTime: [
+            delivery_time ? `${delivery_requested ? 'Delivery' : 'Pickup'}: ${delivery_time}` : '',
+            return_time ? `Return: ${return_time}` : '',
+          ].filter(Boolean).join(', ') || undefined,
+          addOns: validatedAddOns.map((a: ClubRentalAddOn) => ({ label: a.label, price: a.price })),
+          rentalPrice: rental_price,
+          deliveryFee: delivery_fee,
+          totalPrice: total_price,
+          notes: customerNotes || undefined,
+          language: emailLocale,
+        });
+      } catch (err) {
+        console.error('[ClubReserve] Email send error:', err);
+      }
     }
 
     // Send LINE notification for staff
@@ -337,11 +341,19 @@ export async function POST(request: NextRequest) {
         `Please contact the customer to confirm availability and arrange payment.`,
       ].filter(Boolean).join('\n');
 
-      fetch(`${baseUrl}/api/notifications/line`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: lineMessage }),
-      }).catch(err => console.error('[ClubReserve] LINE notification error:', err));
+      try {
+        const lineRes = await fetch(`${baseUrl}/api/notifications/line`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: lineMessage }),
+        });
+        if (!lineRes.ok) {
+          const errBody = await lineRes.text().catch(() => '');
+          console.error(`[ClubReserve] LINE notification failed: ${lineRes.status}`, errBody);
+        }
+      } catch (err) {
+        console.error('[ClubReserve] LINE notification error:', err);
+      }
     }
 
     return NextResponse.json({


### PR DESCRIPTION
## Summary
- Course rental staff LINE notifications and customer emails were silently dropping on cold serverless runtimes — fire-and-forget `fetch()` and `sendCourseRentalConfirmationEmail()` got suspended along with the function before they completed.
- Convert both to `await` inside `try/catch`, matching the working pattern in `app/api/bookings/create/route.ts:149-162` (bay bookings have always awaited).

## Evidence
Vercel runtime logs for **CR-20260508-DD8C** (Melissa Yap, today's reported missing notification):

| Time (UTC) | Path | Status |
|---|---|---|
| 06:40:03 | POST /api/bookings/create | 200 |
| 06:40:05 | POST /api/notifications/line | 200 ← bay booking, awaited |
| **07:01:57** | **POST /api/clubs/reserve** | **200 ← rental inserted** |
| _(no /api/notifications/line call for 2h17m)_ | | |
| 09:18:31 | POST /api/bookings/create | 200 |
| 09:18:38 | POST /api/notifications/line | 200 ← next bay booking, awaited |

The unawaited fetch never reached the LINE route. Cold runtime → response returned → function suspended → in-flight fetch dropped. The pattern was non-deterministic (Tinnawat Nuangjumnong's CR-20260430-E756 on Apr 30 16:29 BKK *did* get a LINE — that was a hot-traffic time of day where the runtime stayed alive long enough for the fetch to complete).

## Trade-offs
- Worst-case `/api/clubs/reserve` response latency rises from ~300ms to ~4s (SMTP + LINE in series). Acceptable for guaranteed staff notification on a low-volume route.
- No timeout wrapping the awaits — a hung SMTP server could hold the response open until Vercel's function timeout (default 10s/60s). Worth knowing but not blocking; can revisit with `Promise.allSettled` + AbortController if it becomes a problem.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] `npm run build` — fails identically with this change stashed (pre-existing worktree path-resolution quirk: `Module not found` inside `node_modules/next/dist/...`). Not introduced by this PR.
- [ ] Manual smoke: trigger a `/course-rental` reservation in production after merge, confirm staff LINE group receives notification and customer email arrives.
- [ ] Regression check: confirm bay-booking LINE notifications still fire (they use the same awaited pattern, should be unaffected).

## Out of scope
- Lengolf-forms `/create-course-rental` staff flow uses a similar client-side fire-and-forget call to `/api/notify`. Browser-side is more reliable than serverless, but still unawaited — separate codebase, follow-up audit recommended.
- Backfill of any earlier missed notifications: 5 customer-facing course rentals between Apr 14 and May 8 are at risk and should be spot-checked against staff LINE chat history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)