### PR TITLE
perf(course-rental): cut LCP and trim barrel-import bundle weight

### DIFF
--- a/app/[locale]/course-rental/page.tsx
+++ b/app/[locale]/course-rental/page.tsx
@@ -618,7 +618,7 @@ export default function CourseRentalPage() {
                 <span>{t('dates.preview.label')}</span>
               </div>
               <div className="grid grid-cols-3 gap-2 sm:gap-3">
-                {PREVIEW_SETS.map((s) => (
+                {PREVIEW_SETS.map((s, idx) => (
                   <div key={s.name} className="flex flex-col items-center">
                     <div className="relative h-16 sm:h-20 w-full bg-white rounded-lg border border-gray-100 flex items-center justify-center overflow-hidden">
                       <Image
@@ -626,7 +626,8 @@ export default function CourseRentalPage() {
                         alt={s.name}
                         fill
                         className="object-contain p-1"
-                        loading="lazy"
+                        priority={idx === 0}
+                        fetchPriority={idx === 0 ? 'high' : 'auto'}
                         sizes="(max-width: 640px) 33vw, 200px"
                       />
                     </div>

--- a/lib/pricing-hook.ts
+++ b/lib/pricing-hook.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, startTransition } from 'react';
 import { getCachedPricing, loadPricing } from '@/lib/pricing';
 
 /**
@@ -13,6 +13,8 @@ export function usePricingLoader(): void {
 
   useEffect(() => {
     if (getCachedPricing()) return;
-    loadPricing().then(() => setLoaded(true));
+    // startTransition marks the post-fetch re-render as non-urgent so it
+    // can't block initial paint or user input on slow mobile CPUs.
+    loadPricing().then(() => startTransition(() => setLoaded(true)));
   }, []);
 }

--- a/next.config.js
+++ b/next.config.js
@@ -7,16 +7,6 @@ const nextConfig = {
   reactStrictMode: true,
   // Fix for ngrok/tunnel asset loading
   assetPrefix: process.env.NEXT_PUBLIC_ASSET_PREFIX || undefined,
-  experimental: {
-    // Tree-shake barrel imports so customer routes don't ship every icon
-    // in @heroicons/react and react-icons/fa. The course-rental page uses
-    // only 6 heroicons and 1 FaLine; without this, the whole barrels ship.
-    optimizePackageImports: [
-      '@heroicons/react/24/outline',
-      '@heroicons/react/24/solid',
-      'react-icons/fa',
-    ],
-  },
   async headers() {
     return [
       {

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,16 @@ const nextConfig = {
   reactStrictMode: true,
   // Fix for ngrok/tunnel asset loading
   assetPrefix: process.env.NEXT_PUBLIC_ASSET_PREFIX || undefined,
+  experimental: {
+    // Tree-shake barrel imports so customer routes don't ship every icon
+    // in @heroicons/react and react-icons/fa. The course-rental page uses
+    // only 6 heroicons and 1 FaLine; without this, the whole barrels ship.
+    optimizePackageImports: [
+      '@heroicons/react/24/outline',
+      '@heroicons/react/24/solid',
+      'react-icons/fa',
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

Booking-app side of the Club Rental Ads funnel fix. Companion PR on the
landing-page side: https://github.com/david2928/lengolf-website/pull/new/claude/club-rental-funnel-20260511

The "Club Rental EN" Google Ads campaign converts at 21% click-to-conv
when it lands, but mature CPA is 297-456 THB vs the 150-200 target.
PageSpeed measured mobile LCP **7.6s** on \`booking.len.golf/course-rental\`
(May 11) — the funnel breaks AFTER the click, not on Ads.

Three minimally-invasive changes:

- **\`priority\` on the first PREVIEW_SETS thumbnail.** Step 1's above-fold
  "Clubs you can rent" row renders from Supabase Storage; cold TTFB +
  \`loading="lazy"\` was costing LCP. Only the first image gets
  \`priority\` + \`fetchPriority="high"\` to avoid bandwidth contention.
- **\`experimental.optimizePackageImports\`** for \`@heroicons/react\` and
  \`react-icons/fa\` so the customer \`/course-rental\` bundle stops shipping
  every icon from those barrels (\`react-icons/fa\` is the bigger win — its
  index.mjs is a single 4,835-line file).
- **\`startTransition\` wrap in \`usePricingLoader\`** so the post-fetch
  \`setLoaded(true)\` re-render is marked non-urgent and can't block
  initial paint when \`/api/pricing\` resolves mid-LCP-window.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — green
- [x] \`npm run test\` — 19/19 actual tests pass (1 pre-existing test-suite
      config issue on \`__tests__/mocks/liff.ts\` — unrelated to this PR)
- [x] Dev preview: Step 1 renders cleanly, no console errors,
      \`fetchPriority="high"\` confirmed on the first thumbnail via DOM
      inspection
- [ ] Mobile PageSpeed on Vercel preview URL — target **perf ≥75,
      LCP <2.5s**. Capture before/after for the PR description.
- [ ] End-to-end mobile-4G timing from landing-page click to usable
      Step 1 form — target **<8s**.
- [ ] Confirm \`course_rental_confirmed\` still fires after a test
      booking in GTM Debug.

## Notes

- The plan said \`modularizeImports\`; I used the Next.js 13.5+ replacement
  \`experimental.optimizePackageImports\` — same goal, no string transform
  to maintain.
- \`/course-rental\` middleware audited: composes to a single internal
  rewrite to \`/en/course-rental\`, no redirect chain hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)