### PR TITLE
fix(i18n): redirect bare-locale URLs to /{locale}/bookings (308)

### DIFF
--- a/__tests__/middleware-smoke.sh
+++ b/__tests__/middleware-smoke.sh
@@ -36,6 +36,22 @@ assert_header() {
   fi
 }
 
+# Like assert_header but tolerates an absolute-URL form. Next.js dev emits
+# relative `Location: /foo`, but Vercel's edge runtime sometimes emits
+# `Location: https://host/foo`. Both are valid for a same-origin redirect.
+assert_location() {
+  local label="$1" expected_path="$2" actual="$3"
+  case "$actual" in
+    "$expected_path"|*"://"*"$expected_path")
+      echo "  PASS [$label] = $actual"
+      ;;
+    *)
+      echo "  FAIL [$label] expected=$expected_path (or absolute form) actual=$actual"
+      fail=1
+      ;;
+  esac
+}
+
 # Helper: returns HTTP status code from HEAD request
 status_of() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
 # Helper: extracts a header value (case-insensitive) from HEAD response
@@ -66,11 +82,22 @@ rewrite=$(header_of "x-middleware-rewrite" "$BASE/")
 assert_status "status" "200" "$status"
 assert_header "x-middleware-rewrite" "/en/bookings" "$rewrite"
 
-echo "Test 5: /th -> 200 (rewritten to /th/bookings)"
+echo "Test 5: /th -> 308 redirect to /th/bookings (canonical localized URL)"
+# Previously this rewrote to /th/bookings, but next-intl's middleware silently
+# collapsed the locale back to `en` downstream — bare-locale URLs rendered
+# with `<html lang="en">` and English content. A 308 forces the browser to
+# fetch the canonical /th/bookings, where the locale resolves correctly.
+# Next.js dev returns Location as a same-origin path; Vercel may emit absolute.
 status=$(status_of "$BASE/th")
-rewrite=$(header_of "x-middleware-rewrite" "$BASE/th")
-assert_status "status" "200" "$status"
-assert_header "x-middleware-rewrite" "/th/bookings" "$rewrite"
+loc=$(header_of "location" "$BASE/th")
+assert_status "status" "308" "$status"
+assert_location "location" "/th/bookings" "$loc"
+
+echo "Test 5b: /ko -> 308 redirect to /ko/bookings (same fix, all locales)"
+status=$(status_of "$BASE/ko")
+loc=$(header_of "location" "$BASE/ko")
+assert_status "status" "308" "$status"
+assert_location "location" "/ko/bookings" "$loc"
 
 # Test 6+: every unprefixed customer route must be matched by middleware and
 # rewritten to its /en/* equivalent. Regression guard for the /course-rental

--- a/middleware.ts
+++ b/middleware.ts
@@ -84,8 +84,8 @@ export async function middleware(request: NextRequest) {
 
   // If next-intl issued a redirect (status 3xx, e.g. cookie-driven `/` → `/th`),
   // pass it through unchanged. The browser will make a follow-up request to
-  // `/th`, where this middleware fires again, sees a bare locale, and rewrites
-  // to `/th/bookings` below.
+  // `/th`, where this middleware fires again, sees a bare non-default locale,
+  // and issues a second 308 to `/th/bookings` (handled by the block below).
   if (intlResponse.status >= 300 && intlResponse.status < 400) {
     return intlResponse;
   }
@@ -99,13 +99,31 @@ export async function middleware(request: NextRequest) {
     : pathname;
 
   // If the effective path resolves to a bare locale root (`/`, `/th`, etc.),
-  // rewrite it to the bookings page for that locale.
+  // route it to the bookings page for that locale. Two behaviors:
+  //
+  // - `/` (default locale): internal rewrite so the URL bar stays `/`. This
+  //   is the long-standing root-rewrite behavior and works correctly because
+  //   the default locale needs no prefix under `localePrefix: 'as-needed'`.
+  //
+  // - `/{locale}` (bare non-default locale, e.g. `/th`, `/ko`): 308 redirect
+  //   to `/{locale}/bookings`. A rewrite here silently collapses the locale
+  //   back to `en` downstream — bare-locale URLs rendered with
+  //   `<html lang="en">` and English content. The redirect forces the browser
+  //   to refetch the canonical `/{locale}/bookings` URL, which next-intl
+  //   resolves correctly. Bonus: the URL bar becomes canonical and matches
+  //   the hreflang alternates emitted for that locale.
   const bareEffective = stripLocale(effectivePath);
   if (bareEffective === '/') {
     const prefix = localePrefix(effectivePath);
     const url = request.nextUrl.clone();
     url.pathname = `${prefix}/bookings`;
-    return NextResponse.rewrite(url);
+
+    const originalIsBareNonDefaultLocale = routing.locales.some(
+      (l) => l !== routing.defaultLocale && pathname === `/${l}`,
+    );
+    return originalIsBareNonDefaultLocale
+      ? NextResponse.redirect(url, 308)
+      : NextResponse.rewrite(url);
   }
 
   // NextAuth session check. A malformed/corrupted JWT cookie throws here —


### PR DESCRIPTION
## Summary
- `booking.len.golf/th`, `/ko`, `/ja`, `/zh` were rendering with `<html lang="en">` and English body content despite the locale prefix in the URL. The middleware's internal rewrite at [middleware.ts:108](middleware.ts) silently collapsed the locale back to `en` downstream.
- Replace the rewrite with a `NextResponse.redirect(url, 308)` for bare non-default-locale URLs so the browser refetches the canonical `/{locale}/bookings`, where next-intl resolves the locale correctly. Keep the existing rewrite for `/` so the default-locale homepage still serves at the root URL.
- The user's perception of "Thai is broken but KO/ZH are fine" comes from the language switcher: `usePathname()` returns `/` at the root, so switching languages there produces `/ko`, `/th`, etc. — bare URLs. Once on one, every subsequent switch keeps `pathname` as `/`, trapping the user. The 308 breaks the trap by moving the URL bar to `/{locale}/bookings`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:middleware` — 13/13 PASS (Test 5 updated to expect 308 + Location header; new Test 5b covers `/ko`)
- [x] Manual curl on local dev: `/th`, `/ko`, `/ja`, `/zh` → 308 → `/{locale}/bookings` → `<html lang="{locale}">` + localized body content verified (Thai: วันนี้/พรุ่งนี้/เลือกวันที่; Korean: 오늘/내일/날짜 선택)
- [x] code-reviewer pass — addressed MAJOR (made test tolerant of absolute-vs-relative Location headers) and NIT (updated stale comment in middleware.ts:85-88)
- [ ] Post-merge production smoke:
  ```bash
  curl -sIL https://booking.len.golf/th | grep -E "(HTTP/|location)"
  # Expect: 308 → /th/bookings → 200
  curl -s https://booking.len.golf/th | grep -oE '<html[^>]*lang="[a-z]{2}"'
  # Expect: <html lang="th"
  ```

## What this does NOT address
- The `<DayPicker>` calendar widget in `app/[locale]/(features)/bookings/components/booking/steps/DateSelection.tsx:385` has no `locale` prop, so its popup month/weekday names stay English in every non-English locale. Separate, smaller follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)