### PR TITLE
fix(i18n): write NEXT_LOCALE cookie in switcher so EN switch works

### DIFF
--- a/components/shared/LanguageSwitcher.tsx
+++ b/components/shared/LanguageSwitcher.tsx
@@ -75,8 +75,24 @@ export function LanguageSwitcher({ variant = 'dark' }: LanguageSwitcherProps = {
   function handleSelect(next: Locale) {
     setOpen(false);
     if (next === locale) return;
+
+    // Write NEXT_LOCALE BEFORE navigating. next-intl v3's `router.replace`
+    // does NOT manage the cookie — the server middleware sets it only when
+    // a locale-prefixed URL is visited (`/th/...`). Switching TO the default
+    // locale (`en`) navigates to an unprefixed URL like `/bookings`, which
+    // the middleware sees alongside the stale cookie and 307-redirects BACK
+    // to `/{stale-locale}/bookings`. The user is then trapped: every "switch
+    // to English" click bounces them to their old locale.
+    //
+    // Match the attributes from i18n/routing.ts → localeCookie so this
+    // cookie shadows (not duplicates) the server-set one. In particular,
+    // Domain=.len.golf in production so it shares with the marketing site.
+    const isProd = window.location.hostname.endsWith('.len.golf');
+    const maxAge = 60 * 60 * 24 * 365; // 1 year, matches routing.ts
+    const domainAttr = isProd ? '; Domain=.len.golf' : '';
+    document.cookie = `NEXT_LOCALE=${next}; Path=/; Max-Age=${maxAge}; SameSite=lax${domainAttr}`;
+
     startTransition(() => {
-      // next-intl writes the NEXT_LOCALE cookie + swaps the URL prefix.
       router.replace(pathname, { locale: next });
       // Best-effort server-side persistence for logged-in users so the
       // preference survives on a different device / browser.

--- a/components/shared/LanguageSwitcher.tsx
+++ b/components/shared/LanguageSwitcher.tsx
@@ -84,12 +84,15 @@ export function LanguageSwitcher({ variant = 'dark' }: LanguageSwitcherProps = {
     // to `/{stale-locale}/bookings`. The user is then trapped: every "switch
     // to English" click bounces them to their old locale.
     //
-    // Match the attributes from i18n/routing.ts → localeCookie so this
-    // cookie shadows (not duplicates) the server-set one. In particular,
-    // Domain=.len.golf in production so it shares with the marketing site.
-    const isProd = window.location.hostname.endsWith('.len.golf');
+    // Match the attributes from i18n/routing.ts → localeCookie EXACTLY so
+    // this cookie shadows (not duplicates) the server-set one. Use the same
+    // `process.env.NODE_ENV === 'production'` predicate as routing.ts —
+    // anything else (e.g. hostname check) drifts on Vercel preview deploys
+    // and any future *.len.golf staging subdomain. Next.js inlines
+    // `process.env.NODE_ENV` for client components at build time.
     const maxAge = 60 * 60 * 24 * 365; // 1 year, matches routing.ts
-    const domainAttr = isProd ? '; Domain=.len.golf' : '';
+    const domainAttr =
+      process.env.NODE_ENV === 'production' ? '; Domain=.len.golf' : '';
     document.cookie = `NEXT_LOCALE=${next}; Path=/; Max-Age=${maxAge}; SameSite=lax${domainAttr}`;
 
     startTransition(() => {


### PR DESCRIPTION
## Summary
- `LanguageSwitcher` was relying on next-intl v3's `router.replace` to set the `NEXT_LOCALE` cookie. It doesn't. The server middleware only sets the cookie when the user lands on a `/{locale}/...` URL.
- Switching TO the default locale (`en`) navigates to an unprefixed URL like `/bookings`. The middleware sees the stale cookie (e.g. `th`) alongside the unprefixed path and 307-redirects BACK to `/th/bookings`. User is trapped — every "English" click bounces them to their current locale.
- Fix: write the `NEXT_LOCALE` cookie client-side **before** `router.replace`, with attributes that match `i18n/routing.ts → localeCookie` exactly (Path=/, Max-Age=1y, SameSite=lax, Domain=.len.golf in prod).

## Reproduction (production curl)
```bash
curl -sI -b "NEXT_LOCALE=th" https://booking.len.golf/bookings
# HTTP/1.1 307 Temporary Redirect
# Location: /th/bookings
# (no Set-Cookie — cookie stays th, user bounces back)
```

## Verification
- [x] Manual switch ZH → EN → TH → KO → EN in dev preview; URL, cookie, and `<html lang>` correct on each step after reload
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Code-reviewer pass — addressed one finding (predicate parity with `routing.ts`, now uses `process.env.NODE_ENV === 'production'` so Vercel preview deploys and any future `staging.len.golf` subdomain behave identically client- and server-side)

## Notes
- Stacked on top of [#24](https://github.com/david2928/lengolf-booking-new/pull/24) (bare-locale redirect fix) — they're complementary: #24 fixes the bare-URL render, this PR fixes the switcher trap.
- Server-side cookie persistence for logged-in users via `/api/user/language` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)