### PR TITLE
fix(clubs): bill course rentals by actual hours, not calendar-date diff

### DIFF
--- a/app/[locale]/course-rental/page.tsx
+++ b/app/[locale]/course-rental/page.tsx
@@ -97,10 +97,19 @@ export default function CourseRentalPage() {
   const [rentalCode, setRentalCode] = useState('');
   const [error, setError] = useState('');
 
-  // Calculate duration from start/end dates
-  const durationDays = (startDate && endDate)
-    ? Math.max(1, Math.round((new Date(endDate).getTime() - new Date(startDate).getTime()) / (1000 * 60 * 60 * 24)))
-    : 0;
+  // Calculate billable duration from pickup/return time, not just calendar dates.
+  // Without this, e.g. pickup 09:00 Sun + return 20:00 Mon (35h) would bill as 1d.
+  // 1-hour grace absorbs minor overruns at handover; anything past 25h tips to 2d.
+  const durationDays = (() => {
+    if (!startDate || !endDate) return 0;
+    if (pickupTime && returnTime) {
+      const pickupMs = new Date(`${startDate}T${pickupTime}:00+07:00`).getTime();
+      const returnMs = new Date(`${endDate}T${returnTime}:00+07:00`).getTime();
+      const billableMs = Math.max(0, returnMs - pickupMs - 3_600_000);
+      return Math.max(1, Math.ceil(billableMs / 86_400_000));
+    }
+    return Math.max(1, Math.round((new Date(endDate).getTime() - new Date(startDate).getTime()) / 86_400_000));
+  })();
 
   // Today's date for min
   const todayStr = (() => {

--- a/app/api/clubs/reserve/route.ts
+++ b/app/api/clubs/reserve/route.ts
@@ -123,6 +123,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid return time format' }, { status: 400 });
     }
 
+    // Course rentals must carry pickup + return time. Without them the server
+    // can't authoritatively compute billable days (see effective_duration_days
+    // below) and would have to trust the client — that was the original bug.
+    if (rental_type === 'course' && (!start_time || !return_time)) {
+      return NextResponse.json(
+        { error: 'Pickup time and return time are required for course rentals' },
+        { status: 400 }
+      );
+    }
+
     // Validate add-ons: use trusted server-side prices AND labels
     // Exclude 'delivery' add-on to prevent double-charging with delivery_fee
     const trustedAddons = getTrustedAddons();
@@ -140,7 +150,10 @@ export async function POST(request: NextRequest) {
         price: trustedAddons[addon.key].price,
       }));
 
-    // Calculate end_date: "1 day" means return next day, so end = start + duration
+    // Calculate end_date: "1 day" means return next day, so end = start + duration.
+    // Contract: an explicit body.end_date wins over duration_days-derived end_date.
+    // The time-aware recompute below is what actually determines billing duration,
+    // so the only role of end_date here is the date range for the availability check.
     let end_date = body.end_date || start_date;
     if (rental_type === 'course' && duration_days && !body.end_date) {
       const start = new Date(start_date);

--- a/app/api/clubs/reserve/route.ts
+++ b/app/api/clubs/reserve/route.ts
@@ -142,10 +142,27 @@ export async function POST(request: NextRequest) {
 
     // Calculate end_date: "1 day" means return next day, so end = start + duration
     let end_date = body.end_date || start_date;
-    if (rental_type === 'course' && duration_days) {
+    if (rental_type === 'course' && duration_days && !body.end_date) {
       const start = new Date(start_date);
       start.setDate(start.getDate() + duration_days);
       end_date = start.toISOString().split('T')[0];
+    }
+
+    // For course rentals, recompute duration_days authoritatively from pickup/return
+    // time so the client can't underpay by spanning >24h within "1 calendar day".
+    // 1-hour grace at handover. Falls back to date diff if times missing.
+    let effective_duration_days = duration_days;
+    if (rental_type === 'course') {
+      if (start_time && return_time) {
+        const pickupMs = new Date(`${start_date}T${start_time}:00+07:00`).getTime();
+        const returnMs = new Date(`${end_date}T${return_time}:00+07:00`).getTime();
+        const billableMs = Math.max(0, returnMs - pickupMs - 3_600_000);
+        effective_duration_days = Math.max(1, Math.ceil(billableMs / 86_400_000));
+      } else if (end_date && end_date !== start_date) {
+        effective_duration_days = Math.max(1, Math.round(
+          (new Date(end_date).getTime() - new Date(start_date).getTime()) / 86_400_000
+        ));
+      }
     }
 
     const supabase = createAdminClient();
@@ -186,8 +203,8 @@ export async function POST(request: NextRequest) {
     let rental_price = 0;
     if (rental_type === 'indoor' && duration_hours) {
       rental_price = getIndoorPrice(clubSet, duration_hours);
-    } else if (rental_type === 'course' && duration_days) {
-      rental_price = getCoursePrice(clubSet, duration_days);
+    } else if (rental_type === 'course' && effective_duration_days) {
+      rental_price = getCoursePrice(clubSet, effective_duration_days);
     }
 
     const add_ons_total = validatedAddOns.reduce((sum: number, item: ClubRentalAddOn) => sum + item.price, 0);
@@ -219,7 +236,7 @@ export async function POST(request: NextRequest) {
         end_date,
         start_time: start_time || null,
         duration_hours: duration_hours || null,
-        duration_days: duration_days || null,
+        duration_days: effective_duration_days || null,
         rental_price,
         add_ons: validatedAddOns.length > 0 ? validatedAddOns : [],
         add_ons_total,
@@ -286,7 +303,7 @@ export async function POST(request: NextRequest) {
           clubSetGender: clubSet.gender,
           startDate: start_date,
           endDate: end_date,
-          durationDays: duration_days || 1,
+          durationDays: effective_duration_days || 1,
           deliveryRequested: delivery_requested,
           deliveryAddress: delivery_address,
           deliveryTime: [
@@ -323,7 +340,7 @@ export async function POST(request: NextRequest) {
 
       const startDateFmt = new Date(start_date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', day: 'numeric', month: 'short' });
       const endDateFmt = new Date(end_date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', day: 'numeric', month: 'short' });
-      const daysLabel = duration_days && duration_days > 1 ? `${duration_days}d` : '1d';
+      const daysLabel = effective_duration_days && effective_duration_days > 1 ? `${effective_duration_days}d` : '1d';
 
       const lineMessage = [
         `Club Rental Notification (${rentalCode})`,


### PR DESCRIPTION
## Summary

- Course-rental duration was `Math.round((endDate - startDate) / 24h)`, ignoring pickup/return time entirely. A booking spanning Sun 09:00 → Mon 20:00 (35h) collapsed to "1d" / ฿1,200, when it should bill as 2d / ฿2,400. Real case: rental code `CR-20260523-1F2D` (Yusuke Baba).
- Client now derives `durationDays` from `(returnDateTime - pickupDateTime)`, applies a **1-hour grace** at handover (so a 25h rental still counts as 1d, but 26h flips to 2d), then ceils.
- Server (`/api/clubs/reserve`) is **authoritative**: it recomputes `effective_duration_days` from `start_date+start_time` and `end_date+return_time` and uses it for pricing, DB row, confirmation email, and the LINE notification. Client-supplied `duration_days` is no longer trusted for course rentals.

## Test plan

- [x] `npm run typecheck` clean
- [x] 9 boundary cases verified via Node (24h=1d, 25h=1d, 26h=2d, 35h=2d, 48h=2d, 49h=2d, 50h=3d, same-day=1d, neg=1d)
- [x] Browser smoke: `/course-rental` with May 24 09:00 → May 25 20:00 now displays "2 days" + ฿2,400 per set
- [ ] Sibling fix in `lengolf-forms` /create-course-rental — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)