### PR TITLE
feat(shopeepay): configurable validity_period_seconds for backoffice callers

### DIFF
--- a/app/api/payments/shopeepay/create/route.ts
+++ b/app/api/payments/shopeepay/create/route.ts
@@ -15,12 +15,17 @@ import { shopeepayConfig } from '@/lib/shopeepay/config';
  * redirect_url instead of creating a duplicate at ShopeePay.
  *
  * Auth: server-only via SUPABASE_SERVICE_ROLE_KEY (createAdminClient).
- * Authorization is implicit — knowing the rental_code is the
- * capability. Rental codes are short (CRYYMMDDXXX) but the
- * /payment/create endpoint never reveals customer-identifying data
- * back to the caller, so a guess yields nothing useful beyond
- * starting a real customer's payment flow (which they'd have to
- * complete from their own ShopeePay app).
+ * Authorization is implicit for the customer flow — knowing the
+ * rental_code is the capability. Rental codes are short
+ * (CRYYMMDDXXX) but the /payment/create endpoint never reveals
+ * customer-identifying data back to the caller, so a guess yields
+ * nothing useful beyond starting a real customer's payment flow
+ * (which they'd have to complete from their own ShopeePay app).
+ *
+ * Backoffice flow: callers may override the link validity window by
+ * supplying `validity_period_seconds` AND a valid `Authorization:
+ * Bearer ${BACKOFFICE_API_TOKEN}` header. Staff issuing links from
+ * lengolf-forms use this path; customers use the default 30 min.
  */
 
 interface CreateBody {
@@ -29,9 +34,56 @@ interface CreateBody {
   platform_type?: 'mweb' | 'pc';
   /** Optional locale-prefixed return path (defaults to /payment/result). */
   return_path?: string;
+  /**
+   * Optional link-validity override in seconds. Requires Bearer auth.
+   * Range [60, 86400]. Customer flow omits this and gets the default.
+   */
+  validity_period_seconds?: number;
 }
 
-const VALIDITY_PERIOD_SECONDS = 1800; // 30 min, matches the cleanup cron window.
+const DEFAULT_VALIDITY_PERIOD_SECONDS = 1800; // 30 min, matches the cleanup cron window.
+const MIN_VALIDITY_PERIOD_SECONDS = 60;
+const MAX_VALIDITY_PERIOD_SECONDS = 86400; // ShopeePay's documented upper bound.
+const BACKOFFICE_TOKEN_MIN_LENGTH = 32;
+
+/**
+ * Constant-time bearer-token compare, mirroring the helper in
+ * app/api/payments/shopeepay/refund/route.ts. Kept in-file (rather
+ * than extracted to a shared module) because the two routes have
+ * subtly different misconfiguration semantics — refund 503s when
+ * the env var is missing because it's strictly a backoffice route,
+ * but here a missing env var only matters when a caller is trying
+ * to use the bearer path.
+ */
+function verifyBearerToken(
+  request: NextRequest
+): { ok: true } | { ok: false; status: number; message: string } {
+  const expected = process.env.BACKOFFICE_API_TOKEN;
+  if (!expected || expected.length < BACKOFFICE_TOKEN_MIN_LENGTH) {
+    return {
+      ok: false,
+      status: 503,
+      message:
+        'Backoffice payment-link path is not configured. Set BACKOFFICE_API_TOKEN (32+ chars) in this environment.',
+    };
+  }
+  const header = request.headers.get('authorization');
+  if (!header || !header.startsWith('Bearer ')) {
+    return { ok: false, status: 401, message: 'Missing or malformed Authorization header' };
+  }
+  const presented = header.slice('Bearer '.length).trim();
+  if (presented.length !== expected.length) {
+    return { ok: false, status: 401, message: 'Invalid token' };
+  }
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= presented.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (diff !== 0) {
+    return { ok: false, status: 401, message: 'Invalid token' };
+  }
+  return { ok: true };
+}
 
 function getBaseUrl(): string {
   if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'development' && process.env.VERCEL_URL) {
@@ -51,7 +103,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { rental_code, platform_type = 'mweb', return_path } = body;
+  const { rental_code, platform_type = 'mweb', return_path, validity_period_seconds } = body;
 
   if (!rental_code || typeof rental_code !== 'string' || rental_code.length > 32) {
     return NextResponse.json({ error: 'rental_code is required' }, { status: 400 });
@@ -63,12 +115,43 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid return_path' }, { status: 400 });
   }
 
+  // Resolve the link validity. Customer flow omits the field and gets
+  // the 30-min default. Backoffice flow (lengolf-forms) supplies it and
+  // must authenticate via bearer token first.
+  let effectiveValidity = DEFAULT_VALIDITY_PERIOD_SECONDS;
+  if (validity_period_seconds !== undefined) {
+    const tokenResult = verifyBearerToken(request);
+    if (!tokenResult.ok) {
+      return NextResponse.json({ error: tokenResult.message }, { status: tokenResult.status });
+    }
+    if (
+      !Number.isInteger(validity_period_seconds) ||
+      validity_period_seconds < MIN_VALIDITY_PERIOD_SECONDS ||
+      validity_period_seconds > MAX_VALIDITY_PERIOD_SECONDS
+    ) {
+      return NextResponse.json(
+        {
+          error: `validity_period_seconds must be an integer in [${MIN_VALIDITY_PERIOD_SECONDS}, ${MAX_VALIDITY_PERIOD_SECONDS}]`,
+        },
+        { status: 400 }
+      );
+    }
+    effectiveValidity = validity_period_seconds;
+  }
+
   const supabase = createAdminClient();
 
   // Look up the rental. v1 only supports course rentals.
+  //
+  // `status` + `expires_at` are read together so the reused-path response
+  // below can use the rental's own expiry without a second query. That
+  // dodges a race with `shopeepay_expire_unpaid_rentals()` (pg_cron, runs
+  // every minute) which sets `expires_at=NULL` + `status='cancelled'` +
+  // flips the matching `payment_transactions.status` to 'failed' in one
+  // transaction.
   const { data: rental, error: rentalError } = await supabase
     .from('club_rentals')
-    .select('id, rental_code, rental_type, total_price, payment_status, customer_name')
+    .select('id, rental_code, rental_type, status, total_price, payment_status, customer_name, expires_at')
     .eq('rental_code', rental_code)
     .single();
 
@@ -81,9 +164,28 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
+  // State-machine guard: a rental that has moved out of the 'reserved'
+  // lifecycle cannot be re-billed. Catches the cleanup-cron race (where
+  // a rental is auto-cancelled before the customer pays) and the staff
+  // who-cancelled-then-tried-to-resend case.
+  if (rental.status !== 'reserved') {
+    return NextResponse.json(
+      { error: `Cannot create payment link for rental in '${rental.status}' state` },
+      { status: 409 }
+    );
+  }
   if (rental.payment_status === 'paid') {
     return NextResponse.json(
       { error: 'This rental has already been paid' },
+      { status: 409 }
+    );
+  }
+  // partially_refunded / refunded are terminal on the payment side — even
+  // if the lifecycle is still 'reserved' for some reason, do not let staff
+  // mint another payment link against a refunded rental.
+  if (rental.payment_status === 'refunded' || rental.payment_status === 'partially_refunded') {
+    return NextResponse.json(
+      { error: 'This rental has been refunded and cannot be re-billed' },
       { status: 409 }
     );
   }
@@ -101,10 +203,17 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
 
   if (existing && existing.redirect_url) {
+    // Use rental.expires_at as read above — the prior code re-SELECTed
+    // expires_at here, which opened a race window with the cleanup cron
+    // that nulls expires_at while we're between queries. Reading once
+    // up-front + the status-guard above eliminates that.
+    // We do NOT extend the window here — the original validity wins;
+    // that's the booking-app's idempotency contract.
     return NextResponse.json({
       success: true,
       redirect_url: existing.redirect_url,
       payment_reference_id: existing.payment_reference_id,
+      expires_at: rental.expires_at,
       reused: true,
     });
   }
@@ -171,7 +280,7 @@ export async function POST(request: NextRequest) {
       currency: 'THB',
       return_url: returnUrl,
       platform_type,
-      validity_period: VALIDITY_PERIOD_SECONDS,
+      validity_period: effectiveValidity,
       additional_info: additionalInfo,
     });
   } catch (e) {
@@ -221,12 +330,13 @@ export async function POST(request: NextRequest) {
     // Non-fatal — we still got a redirect URL. Continue.
   }
 
+  const expiresAtIso = new Date(Date.now() + effectiveValidity * 1000).toISOString();
   await supabase
     .from('club_rentals')
     .update({
       payment_status: 'pending',
       payment_transaction_id: txnRow.id,
-      expires_at: new Date(Date.now() + VALIDITY_PERIOD_SECONDS * 1000).toISOString(),
+      expires_at: expiresAtIso,
     })
     .eq('id', rental.id);
 
@@ -236,6 +346,7 @@ export async function POST(request: NextRequest) {
     success: true,
     redirect_url: shopeeResp.redirect_url_http,
     payment_reference_id: paymentReferenceId,
+    expires_at: expiresAtIso,
     gateway_environment: shopeepayConfig.isProductionEnv ? 'production' : 'staging',
   });
 }


### PR DESCRIPTION
## Summary

Extends the existing customer-facing `/api/payments/shopeepay/create` endpoint to accept an optional `validity_period_seconds` parameter (range 60–86400) when called with `Authorization: Bearer ${BACKOFFICE_API_TOKEN}`. Customer flow is unchanged (still 30-min default). Mirrors the bearer-auth pattern from the refund route.

Also tightens state-machine validation: rental.status must be 'reserved' (previously unchecked — a cancelled rental could be re-billed by anyone with the rental_code).

## Why

Unblocks lengolf-forms staff-issued payment links for course rentals — see [lengolf-forms#TBD](https://github.com/david2928/lengolf-forms/pull/new/session-20260527-staff-payment-link). Staff typically need a longer payment window than the customer-immediate 30 min (default 24h in the staff flow).

## Behavioural changes

| Caller | Behaviour |
|---|---|
| Customer flow (no bearer, no `validity_period_seconds`) | Unchanged — 30 min default |
| Backoffice with valid bearer + `validity_period_seconds` | Uses supplied value (validated 60..86400) |
| Backoffice with `validity_period_seconds` but no/invalid bearer | 401 / 503 |
| Any caller against a cancelled / returned / etc. rental | 409 "Cannot create payment link for rental in 'X' state" |

## Race fix (from code review)

The reused-path previously re-SELECTed `expires_at` after the `payment_transactions` lookup, racing with `shopeepay_expire_unpaid_rentals()` (pg_cron, every minute) which sets `expires_at = NULL` + flips both `club_rentals.status='cancelled'` and `payment_transactions.status='failed'` in one transaction. The fix consolidates the rental SELECT to include `status` + `expires_at` up front and uses that value in the reused-path response.

## Test plan

- [ ] Customer flow: open `/course-rental`, complete a booking, hit `/payment/start` — confirm a ShopeePay UAT redirect URL with a 30-min expiry is generated
- [ ] Backoffice flow (after lengolf-forms PR is merged): generate from `/manage-club-rentals` row action with 4h validity, confirm ShopeePay URL works
- [ ] State-machine guard: try `POST /api/payments/shopeepay/create` with a `rental_code` of a cancelled rental — expect 409
- [ ] Auth: try POST with `validity_period_seconds: 7200` but no bearer — expect 401
- [ ] Auth: try POST with bearer but `validity_period_seconds: 100000` (over cap) — expect 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)