### PR TITLE
feat(shopeepay): short-URL redirector at /p/[rental_code]

### DIFF
--- a/app/p/[rental_code]/route.ts
+++ b/app/p/[rental_code]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/utils/supabase/admin';
+
+/**
+ * GET /p/[rental_code]
+ *
+ * Public short-URL redirector for staff-issued ShopeePay payment links.
+ * Staff in lengolf-forms generate a payment link, copy the short URL
+ * (e.g. https://booking.len.golf/p/CR-20260526-B626) and paste it into
+ * LINE / WhatsApp / wherever they chat with the customer. On click, this
+ * route looks up the latest pending payment_transactions row for that
+ * rental and 302's to ShopeePay's full redirect_url.
+ *
+ * Behaviour:
+ * - Pending payment found        → 302 to ShopeePay redirect_url
+ * - Rental paid                  → 302 to /payment/result?ref=<code>  (existing page renders the paid state)
+ * - Rental cancelled / refunded  → 302 to /payment/result?ref=<code>&missing=1
+ * - rental_code not found        → 404 with a short HTML message
+ *
+ * The rental_code is the capability — same security model as
+ * /api/payments/shopeepay/create. We never echo any rental fields back
+ * to the caller; a guessed code just yields a redirect to ShopeePay's
+ * own checkout page (which the guesser cannot complete without the
+ * legitimate customer's ShopeePay app).
+ */
+
+const RENTAL_CODE_PATTERN = /^CR-\d{8}-[A-Z0-9]{1,20}$/;
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ rental_code: string }> }
+) {
+  const { rental_code } = await params;
+
+  if (!rental_code || rental_code.length > 32 || !RENTAL_CODE_PATTERN.test(rental_code)) {
+    return new NextResponse('Invalid rental code', { status: 400, headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: rental } = await supabase
+    .from('club_rentals')
+    .select('id, payment_status, status')
+    .eq('rental_code', rental_code)
+    .maybeSingle();
+
+  if (!rental) {
+    return new NextResponse('Payment link not found', { status: 404, headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  // Build a base URL for relative redirects (e.g. to /payment/result).
+  // The request is already on this domain, so prefer the request's origin
+  // when reachable, falling back to known env vars.
+  function resultUrl(suffix: string = ''): string {
+    const envBase = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || '';
+    const base = envBase.replace(/\/$/, '');
+    const path = `/payment/result?ref=${encodeURIComponent(rental_code)}${suffix}`;
+    return base ? `${base}${path}` : path;
+  }
+
+  // Terminal payment states — show the result page rather than hitting ShopeePay.
+  if (rental.payment_status === 'paid' || rental.payment_status === 'refunded' || rental.payment_status === 'partially_refunded') {
+    return NextResponse.redirect(resultUrl(), 302);
+  }
+  if (rental.status === 'cancelled' || rental.status === 'returned') {
+    return NextResponse.redirect(resultUrl('&missing=1'), 302);
+  }
+
+  // Find the most recent pending payment_transactions row for this rental.
+  const { data: txn } = await supabase
+    .from('payment_transactions')
+    .select('redirect_url, status')
+    .eq('club_rental_id', rental.id)
+    .eq('status', 'pending')
+    .not('redirect_url', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!txn?.redirect_url) {
+    // Rental exists but no active payment link — surface the result page so
+    // the customer sees a graceful "no link" instead of a bare 404.
+    return NextResponse.redirect(resultUrl('&missing=1'), 302);
+  }
+
+  return NextResponse.redirect(txn.redirect_url, 302);
+}


### PR DESCRIPTION
## Summary

Lets lengolf-forms staff share a short, stable URL instead of the ~1500-char ShopeePay redirect URL when issuing payment links. Click → 302 to the current pending ShopeePay redirect.

Before: `https://app.shopeepay.co.th/u/pay_checkout?type=start&mid=13064056&target_app=shopeepay&_apprl_=%2Frn%2F%40shopee-rn%2Fshopeepay%2FTRANSFER_PAYMENT_SELECTION_CSCANB...` (~1500 chars)
After: `https://booking.len.golf/p/CR-20260526-B626` (~40 chars)

## Why short, not random opaque slug

Keying off `rental_code` rather than a per-link random slug means staff can re-issue links (idempotency hit / expiry + new link) and the short URL stays the same. Customers can re-use the link they were sent. The `rental_code` is already the capability for `/api/payments/shopeepay/create`, so no new security surface.

## Edge cases handled

| Rental state | Behaviour |
|---|---|
| Pending payment exists | 302 to ShopeePay redirect_url |
| Rental `payment_status='paid'` / `refunded` / `partially_refunded` | 302 to `/payment/result?ref=<code>` (existing result page) |
| Rental `status='cancelled'` / `returned` | 302 to `/payment/result?ref=<code>&missing=1` |
| rental_code not found / malformed | 404 with plain-text message |

## Depends on

This PR pairs with [lengolf-forms PR](https://github.com/david2928/lengolf-forms/pull/new/session-20260527-discount-and-shortlink) which updates the staff modal to display the short URL. Merge this one first so the redirector is live before forms starts pointing at it.

## Test plan

- [ ] Hit `https://booking.len.golf/p/CR-<some-pending-rental>` and confirm 302 to ShopeePay's checkout
- [ ] Hit with a paid rental_code → 302 to /payment/result
- [ ] Hit with a malformed code (e.g. `/p/foo`) → 400
- [ ] Hit with a valid format but non-existent code → 404
- [ ] Confirm no regression on the customer flow (`/course-rental`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)