### PR TITLE
feat(analytics): course-rental funnel telemetry

### DIFF
--- a/app/[locale]/course-rental/page.tsx
+++ b/app/[locale]/course-rental/page.tsx
@@ -143,6 +143,18 @@ export default function CourseRentalPage() {
     setHeroIndex(0);
   }, [selectedSet?.id]);
 
+  // Funnel telemetry: push a step-viewed event whenever the user advances.
+  // GTM trigger "Course Rental Step Viewed" fans this out to GA4
+  // (event: course_rental_step_viewed) so we can build a per-step drop-off
+  // funnel alongside the existing course_rental_confirmed conversion.
+  useEffect(() => {
+    pushEventToGtm('course_rental_step_viewed', {
+      step,
+      step_index: step === 'confirmation' ? STEP_ORDER.length : STEP_ORDER.indexOf(step),
+      total_steps: STEP_ORDER.length,
+    });
+  }, [step]);
+
   // Prefill contact fields for logged-in customers from VIP profile.
   // Mirrors the BookingDetails approach (sessionStorage cache + /api/vip/profile).
   useEffect(() => {
@@ -311,6 +323,12 @@ export default function CourseRentalPage() {
           });
           const payData = await payRes.json();
           if (payRes.ok && payData?.redirect_url) {
+            pushEventToGtm('course_rental_payment_redirect', {
+              rental_code: data.rental_code,
+              conversion_value: totalPrice,
+              currency: 'THB',
+              platform_type: platformType,
+            });
             window.location.href = payData.redirect_url;
             return;
           }


### PR DESCRIPTION
## Summary

Wires per-step + payment-redirect tracking into the `/course-rental` flow so we can finally measure the funnel from landing → submit → ShopeePay click-through. Before this, GTM only had `course_rental_confirmed` (fired at step-5 submit), so there was no way to see step-by-step drop-off.

Two new events:

- **`course_rental_step_viewed`** — fires on every step transition (`dates` → `set` → `delivery` → `contact` → `review` → `confirmation`). Payload: `step`, `step_index` (0-based), `total_steps`. Single `useEffect` on `[step]`.
- **`course_rental_payment_redirect`** — fires immediately before the `window.location.href = ShopeePay redirect_url` hand-off. Payload: `rental_code`, `conversion_value`, `currency`, `platform_type` (`mweb`|`pc`). Distinguishes "submitted reservation" from "actually clicked through to gateway" — the existing `course_rental_confirmed` conflates them.

## GTM container companion (already published — version 18)

| Resource | ID |
|---|---|
| DLV `step` | #112 |
| DLV `step_index` | #113 |
| DLV `platform_type` | #110 |
| Trigger `Course Rental Step Viewed` (`customEvent`) | #111 |
| Trigger `Course Rental Payment Redirect` (`customEvent`) | #114 |
| Tag `GA4 - Course Rental Step Viewed` (`gaawe` → G-08BZ5M40SG) | #115 |
| Tag `GA4 - Course Rental Payment Redirect` (`gaawe` → G-08BZ5M40SG) | #116 |

Container `GTM-MKCHVJKW` published cleanly (no compiler errors). Will start firing from GA4's side as soon as this PR is deployed.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no warnings
- [x] `npm run build` — clean (pulled ShopeePay env vars locally to satisfy module-load assertion)
- [x] Dev server smoke test: loaded `/course-rental`, `window.dataLayer` captured `{event:"course_rental_step_viewed", step:"dates", step_index:0, total_steps:5}`
- [ ] After deploy: confirm `course_rental_step_viewed` appears in GA4 DebugView with non-zero counts at each `step_index`
- [ ] After deploy: walk through one full reservation in UAT, confirm `course_rental_payment_redirect` fires immediately before the ShopeePay tab takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)